### PR TITLE
More separation of development from production environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,21 @@
 # Port to run the server on
 PORT=3000
+
 # AVWX token for weather (not yet used)
 AVWX_TOKEN=
+
 # Callsign of your station
-CALLSIGN=NKS
+DISPATCH_CALLSIGN=NKS
+
 # Hoppie logon code
 HOPPIE_LOGON=
+
 # Set to false to send messages to HOPPIE instead of logging them out
 DEV_MODE=true
+
+# Set to a valid tslog level for the minimum log level to output https://tslog.js.org/#/?id=minlevel
+LOG_LEVEL=
+
 # Footer to display at bottom of transmissions
 FOOTER='
 [BETA] AUTOMATED SERVICE

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon src/index.ts",
+    "dev": "nodemon --watch src --watch .env src/index.ts",
     "build": "tsc",
     "start": "node .",
     "lint": "eslint .",

--- a/src/getGate.ts
+++ b/src/getGate.ts
@@ -1,9 +1,7 @@
 import _ from 'lodash'
-import { Logger } from 'tslog'
+import { log } from './log'
 
 import { arrGatesAssigned } from './caches'
-
-const gateLogger = new Logger({ name: 'gateLogger' })
 
 interface Gate {
   gateNumber: string
@@ -32,7 +30,7 @@ const getGate = (station: Station, international: boolean): Gate | null => {
     .map(({ gateNumber }) => gateNumber)
 
   if (station.gates.length === 0) {
-    gateLogger.warn(`No gate found at ${station.icao}.`)
+    log.warn(`No gate found at ${station.icao}.`)
     return null
   }
 
@@ -67,9 +65,9 @@ const getGate = (station: Station, international: boolean): Gate | null => {
       `${station.icao}/${chosenGate.gateNumber}`.toUpperCase(),
       true
     )
-    gateLogger.info(`Assigning gate ${chosenGate.gateNumber} at ${station.icao}.`)
+    log.info(`Assigning gate ${chosenGate.gateNumber} at ${station.icao}.`)
   } else {
-    gateLogger.info(`No gates found for ${station.icao}.`)
+    log.info(`No gates found for ${station.icao}.`)
   }
 
   return chosenGate ?? null

--- a/src/hoppie.ts
+++ b/src/hoppie.ts
@@ -27,7 +27,7 @@ export const hoppieString = (
   packet: string | undefined = undefined,
   to: string | undefined = undefined
 ) => {
-  const CALLSIGN = process.env.CALLSIGN
+  const CALLSIGN = process.env.DISPATCH_CALLSIGN
   const HOPPIE_LOGON = process.env.HOPPIE_LOGON
 
   if (!CALLSIGN || !HOPPIE_LOGON) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config'
+import { log } from './log'
 import { arrivalMessage } from './arrivalMessage'
 import { schedule } from 'node-cron'
 
@@ -10,15 +11,26 @@ const checkEnv = function(envs: string[]) {
   }
 }
 
-checkEnv(['CALLSIGN']);
+for (const env of [
+  'NODE_ENV',
+  'DEV_MODE',
+  'LOG_LEVEL',
+  'DISPATCH_CALLSIGN',
+]) {
+  log.debug(env, process.env[env]);
+};
+
+checkEnv(['DISPATCH_CALLSIGN']);
 if (process.env.DEV_MODE == 'false') {
   checkEnv(['HOPPIE_LOGON']);
+  log.info('Starting scheduler');
   schedule('* * * * *', () => {
     void (async () => {
       await arrivalMessage();
     })();
   });
 } else {
+  log.info('DEV_MODE is on - running once')
   void (async () => {
      await arrivalMessage();
   })();

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,10 @@
+import { Logger, TLogLevelName } from 'tslog'
+
+let min_level = process.env.LOG_LEVEL;
+if (!min_level) {
+  min_level = 'info'
+}
+
+export const log = new Logger({
+  minLevel: min_level as TLogLevelName
+});


### PR DESCRIPTION
* if NODE_ENV not in production overwrite to DISPATCH_CALLSIGN + 'OUT'
* changes CALLSIGN to DISPATCH_CALLSIGN
* throws an error when an invalid HOPPIE_LOGON is supplied in the Hoppie request
* consolidates log configuration
* adds LOG_LEVEL env variable to set minimum log level
* dev nodemon now also monitors .env